### PR TITLE
Windows: support VM-based runtimes like nerdbox

### DIFF
--- a/core/mount/mount_windows.go
+++ b/core/mount/mount_windows.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/Microsoft/go-winio/pkg/bindfilter"
 	"github.com/Microsoft/hcsshim"
+	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	"golang.org/x/sys/windows"
 )
@@ -36,7 +37,12 @@ const sourceStreamName = "containerd.io-source"
 // Mount to the provided target.
 func (m *Mount) mount(target string) (retErr error) {
 	if m.Type != "windows-layer" {
-		return fmt.Errorf("invalid windows mount type: '%s'", m.Type)
+		// Return ErrNotImplemented for non-Windows mount types (e.g.
+		// ext4, overlay, erofs) so the mount manager can defer them to
+		// the container runtime. This matches Darwin where mount()
+		// always returns ErrNotImplemented, and enables VM-based
+		// runtimes like nerdbox that handle mounts inside the guest.
+		return errdefs.ErrNotImplemented
 	}
 
 	home, layerID := filepath.Split(m.Source)

--- a/pkg/oci/spec.go
+++ b/pkg/oci/spec.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
-	"runtime"
 
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -94,10 +93,12 @@ func generateDefaultSpecWithPlatform(ctx context.Context, platform, id string, s
 		err = populateDefaultDarwinSpec(s)
 	default:
 		err = populateDefaultUnixSpec(ctx, s, id)
-		if err == nil && runtime.GOOS == "windows" {
-			// To run LCOW we have a Linux and Windows section. Add an empty one now.
-			s.Windows = &specs.Windows{}
-		}
+		// Note: Previously this added an empty s.Windows section for LCOW
+		// (Linux Containers on Windows via Hyper-V). This is not needed for
+		// VM-based runtimes like nerdbox that run a full Linux VM, and it
+		// causes container runtimes inside the VM (e.g. crun) to fail with
+		// "Required field 'layerFolders' not present". LCOW users should
+		// set the Windows section explicitly via spec options if needed.
 	}
 
 	return err


### PR DESCRIPTION
Make the Windows host behave more like macOS when running Linux containers inside VMs via runtimes like nerdbox/libkrun.

Two changes:

1. mount_windows.go: Return `ErrNotImplemented` for non-Windows mount types (ext4, overlay, erofs). This matches Darwin.

2. spec.go: Don't add an empty spec.Windows section when generating a Linux container spec on a Windows host. The empty Windows section was added for LCOW (Linux Containers on Windows via Hyper-V), but it causes container runtimes inside VMs (e.g. crun) to fail with "Required field 'layerFolders' not present". VM-based runtimes don't use LCOW — they run a full Linux kernel. LCOW users can set the Windows section explicitly via spec options if needed.