### PR TITLE
Fix WithPidsLimit: use pointer for Pids.Limit assignment

### DIFF
--- a/pkg/oci/spec_opts.go
+++ b/pkg/oci/spec_opts.go
@@ -1601,7 +1601,7 @@ func WithPidsLimit(limit int64) SpecOpts {
 		if s.Linux.Resources.Pids == nil {
 			s.Linux.Resources.Pids = &specs.LinuxPids{}
 		}
-		s.Linux.Resources.Pids.Limit = limit
+		s.Linux.Resources.Pids.Limit = &limit
 		return nil
 	}
 }


### PR DESCRIPTION
## Summary

`specs.LinuxPids.Limit` is typed as `*int64`, but `WithPidsLimit` was assigning a plain `int64` value directly:

```go
// Before (broken):
s.Linux.Resources.Pids.Limit = limit

// After (fixed):
s.Linux.Resources.Pids.Limit = &limit
```

This causes a compilation error in downstream consumers (e.g. `github.com/containerd/nerdbox`) that import this package with a version of the OCI runtime spec where `LinuxPids.Limit` is a pointer type.

The `main` branch already has the correct `= &limit` form; this patch brings the `erofs-darwin` branch in line with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)