### PR TITLE
shim: implement log pipe on Windows

### DIFF
--- a/pkg/shim/shim_windows.go
+++ b/pkg/shim/shim_windows.go
@@ -23,8 +23,10 @@ import (
 	"net"
 	"os"
 	"os/signal"
+	"sync"
 
 	winio "github.com/Microsoft/go-winio"
+	"github.com/containerd/containerd/v2/pkg/namespaces"
 	"github.com/containerd/log"
 	"github.com/containerd/ttrpc"
 )
@@ -104,8 +106,46 @@ func handleExitSignals(ctx context.Context, logger *log.Entry, cancel context.Ca
 	}
 }
 
-func openLog(ctx context.Context, _ string) (io.Writer, error) {
-	// On Windows, just return stderr for logging
-	// We don't have FIFO support like Unix
-	return os.Stderr, nil
+func openLog(ctx context.Context, id string) (io.Writer, error) {
+	ns, err := namespaces.NamespaceRequired(ctx)
+	if err != nil {
+		return os.Stderr, nil
+	}
+	pipeName := fmt.Sprintf(`\\.\pipe\containerd-shim-%s-%s-log`, ns, id)
+	l, err := winio.ListenPipe(pipeName, nil)
+	if err != nil {
+		return os.Stderr, nil
+	}
+
+	w := &pipeLogWriter{}
+	go func() {
+		c, err := l.Accept()
+		l.Close()
+		if err != nil {
+			return
+		}
+		w.mu.Lock()
+		w.conn = c
+		w.mu.Unlock()
+	}()
+	return w, nil
+}
+
+// pipeLogWriter writes to os.Stderr always, and also to the named pipe
+// connection once containerd has connected to it.
+type pipeLogWriter struct {
+	mu   sync.Mutex
+	conn net.Conn
+}
+
+func (w *pipeLogWriter) Write(p []byte) (int, error) {
+	n, err := os.Stderr.Write(p)
+
+	w.mu.Lock()
+	c := w.conn
+	w.mu.Unlock()
+	if c != nil {
+		c.Write(p) //nolint:errcheck
+	}
+	return n, err
 }


### PR DESCRIPTION


The openLog() stub on Windows returned os.Stderr, so shim logs (including VM console output from nerdbox) were never delivered to containerd's log aggregation. The reader side (openShimLog) already connects to a named pipe:

```
  \.\pipe\containerd-shim-{namespace}-{id}-log
```

See https://github.com/containerd/containerd/blob/6667c769ecf6/core/runtime/v2/shim_windows.go#L76

but the writer side never created it.

Implement openLog() to create the matching named pipe via winio.ListenPipe and return a pipeLogWriter that:
- Always writes to os.Stderr (so logs work even without containerd)
- Also writes to the pipe once containerd connects

Errors creating or accepting the pipe are non-fatal: openLog falls back to os.Stderr so the shim still starts.

On Unix I think the stderr is captured via
```golang
  // shim_unix.go                                                                                      func openLog(ctx context.Context, _ string) (io.Writer, error) {
      return fifo.OpenFifoDup2(ctx, "log", unix.O_WRONLY, 0700, int(os.Stderr.Fd()))
  }
```